### PR TITLE
Update GenerateRows.php

### DIFF
--- a/libraries/BatchUpload/Job/GenerateRows.php
+++ b/libraries/BatchUpload/Job/GenerateRows.php
@@ -201,6 +201,7 @@ class BatchUpload_Job_GenerateRows extends Omeka_Job_AbstractJob {
             // If there are uploads, create a job data row with { "file": "str", "fileid": null, "order": int, "item": int }
             if (!empty($uploads))
             {
+                $uploads = array_filter($uploads); //filter out empty file uploads created through separation
                 foreach ($uploads as $uploadNum => $upload)
                 {
                     $newJobRow = new BatchUpload_Row();


### PR DESCRIPTION
Hello, I was using this plugin to upload files, specifically the multi subfields experimental branch. While doing so I encountered a bug when uploading multiple files for one item. For some reason, it was creating empty files in addition to the right files, so that in the file upload step, it was expecting additional files that I could not provide.

Here is one of the records for an empty file in the batch_upload_rows table in the database:

`(48,16,2,'{\"file\":\"\",\"fileOrder\":2,\"fileId\":null,\"item\":45}')`

To fix it, I used the php [array_filter](https://secure.php.net/manual/en/function.array-filter.php) method to remove empty elements from the uploads array before the array was inserted into the database. This seems to have solved the problem.