### PR TITLE
Add Mixin_Timestamp to Job and MappingSet to avoid "Column 'added' ca…

### DIFF
--- a/controllers/MappingSetsController.php
+++ b/controllers/MappingSetsController.php
@@ -125,7 +125,7 @@ class BatchUpload_MappingSetsController extends BatchUpload_Application_Abstract
     /**
      * Override the redirect after editing a mapping template back to browse.
      */
-    protected function _redirectAfterEdit()
+    protected function _redirectAfterEdit($record)
     {
         $this->_helper->redirector('browse', null, null, array());
     }

--- a/models/BatchUpload/Job.php
+++ b/models/BatchUpload/Job.php
@@ -92,7 +92,9 @@ class BatchUpload_Job extends Omeka_Record_AbstractRecord
      */
     protected function _initializeMixins()
     {
+        parent::_initializeMixins();
         $this->_mixins[] = new Mixin_Owner($this);
+        $this->_mixins[] = new Mixin_Timestamp($this, 'added', null);
     }
 
     /**

--- a/models/BatchUpload/Job.php
+++ b/models/BatchUpload/Job.php
@@ -94,7 +94,7 @@ class BatchUpload_Job extends Omeka_Record_AbstractRecord
     {
         parent::_initializeMixins();
         $this->_mixins[] = new Mixin_Owner($this);
-        $this->_mixins[] = new Mixin_Timestamp($this, 'added', null);
+        $this->_mixins[] = new Mixin_Timestamp($this);
     }
 
     /**

--- a/models/BatchUpload/MappingSet.php
+++ b/models/BatchUpload/MappingSet.php
@@ -58,7 +58,9 @@ class BatchUpload_MappingSet extends Omeka_Record_AbstractRecord
      */
     protected function _initializeMixins()
     {
+        parent::_initializeMixins();
         $this->_mixins[] = new Mixin_Owner($this);
+        $this->_mixins[] = new Mixin_Timestamp($this, 'added', null);
     }
 
     /**

--- a/models/BatchUpload/MappingSet.php
+++ b/models/BatchUpload/MappingSet.php
@@ -60,7 +60,7 @@ class BatchUpload_MappingSet extends Omeka_Record_AbstractRecord
     {
         parent::_initializeMixins();
         $this->_mixins[] = new Mixin_Owner($this);
-        $this->_mixins[] = new Mixin_Timestamp($this, 'added', null);
+        $this->_mixins[] = new Mixin_Timestamp($this);
     }
 
     /**


### PR DESCRIPTION
This addresses [GitHub issue #7](https://github.com/utlib/BatchUpload/issues/7), where a `Column 'added' cannot be null` error appears on a MySQL 5.7 setup.