### PR TITLE
Patches for Omeka Classic 3.1.x compatibility

### DIFF
--- a/libraries/BatchUpload/Application/DataContainer.php
+++ b/libraries/BatchUpload/Application/DataContainer.php
@@ -21,7 +21,7 @@ class BatchUpload_Application_DataContainer implements JsonSerializable
      * Implementation of JsonSerializable.
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize() : mixed
     {
         return json_encode($this->_data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
     }

--- a/views/shared/css/general.css
+++ b/views/shared/css/general.css
@@ -1,3 +1,19 @@
 .inputs ul.error {
     clear: both;
 }
+
+#metadata-table {
+    table-layout: fixed;
+}
+
+#metadata-table thead th:nth-child(4), #metadata-table thead th:nth-child(5) {
+    width: 4em;
+}
+
+#metadata-table td {
+    word-wrap: break-word;
+}
+
+#metadata-table select {
+    max-width: 100%;
+}


### PR DESCRIPTION
- Remove incompatible type warning on `jsonSerialize()` method
- Fix table overflow on import form